### PR TITLE
Fix admin pages to align with cursor rules

### DIFF
--- a/app/(admin)/admin/_components/AdminDashboard.tsx
+++ b/app/(admin)/admin/_components/AdminDashboard.tsx
@@ -2,11 +2,28 @@
 
 import Link from 'next/link';
 
+import { cva, type VariantProps } from 'class-variance-authority';
 import { StatCard, RecentPostsCard } from '@/(admin)/_components';
 import { Button } from '@/(common)/_components/ui/button';
 import { EyeIcon, CheckIcon, ClockIcon } from '@/_icons';
+import { cn } from '@/_libs';
 
-export function AdminDashboard() {
+const AdminDashboardVariants = cva(
+  [
+    'p-8',
+  ],
+  {
+    variants: {},
+    defaultVariants: {},
+    compoundVariants: [],
+  }
+);
+
+interface AdminDashboardProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof AdminDashboardVariants> {}
+
+export function AdminDashboard({ className, ...props }: AdminDashboardProps) {
   // TODO: 실제 데이터로 교체
   const recentPosts = [
     {
@@ -66,7 +83,13 @@ export function AdminDashboard() {
   ];
 
   return (
-    <div className='p-8'>
+    <div
+      className={cn(
+        AdminDashboardVariants({}),
+        className,
+      )}
+      {...props}
+    >
       <div className='flex justify-between items-center mb-8'>
         <div>
           <h1 className='text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2'>대시보드</h1>

--- a/app/(admin)/admin/categories/_components/AdminCategories.tsx
+++ b/app/(admin)/admin/categories/_components/AdminCategories.tsx
@@ -4,11 +4,13 @@ import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { FiPlus, FiTag } from 'react-icons/fi';
 
+import { cva, type VariantProps } from 'class-variance-authority';
 import { CategoryList, CategoryForm, CategoryStatistics } from '.';
 
 import { Button } from '@/(common)/_components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/(common)/_components/ui/card';
 import { CategoriesApi } from '@/_entities/categories';
+import { cn } from '@/_libs';
 import type { Category } from '@/_prisma/client';
 
 interface CategoryWithCount extends Category {
@@ -16,7 +18,22 @@ interface CategoryWithCount extends Category {
   published_post_count: number;
 }
 
-export function AdminCategories() {
+const AdminCategoriesVariants = cva(
+  [
+    'min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-slate-900 dark:via-slate-800 dark:to-purple-900 p-6',
+  ],
+  {
+    variants: {},
+    defaultVariants: {},
+    compoundVariants: [],
+  }
+);
+
+interface AdminCategoriesProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof AdminCategoriesVariants> {}
+
+export function AdminCategories({ className, ...props }: AdminCategoriesProps) {
   const [ showForm, setShowForm, ] = useState(false);
   const [ editingCategory, setEditingCategory, ] = useState<CategoryWithCount | null>(null);
 
@@ -31,24 +48,24 @@ export function AdminCategories() {
 
   const categories = (categoriesResponse?.response || []) as CategoryWithCount[];
 
-  const handleNewCategory = () => {
+  const onClickNewCategory = () => {
     setEditingCategory(null);
     setShowForm(true);
   };
 
-  const handleEditCategory = (category: CategoryWithCount) => {
+  const onClickEditCategory = (category: CategoryWithCount) => {
     setEditingCategory(category);
     setShowForm(true);
   };
 
-  const handleCloseForm = () => {
+  const onCloseCategoryForm = () => {
     setShowForm(false);
     setEditingCategory(null);
   };
 
   if (isLoading) {
     return (
-      <div className='min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-slate-900 dark:via-slate-800 dark:to-purple-900 p-6'>
+      <div className={cn(AdminCategoriesVariants({}), className)} {...props}>
         <div className='max-w-7xl mx-auto'>
           <div className='flex items-center justify-center h-64'>
             <div className='text-center'>
@@ -63,7 +80,7 @@ export function AdminCategories() {
 
   if (error) {
     return (
-      <div className='min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-slate-900 dark:via-slate-800 dark:to-purple-900 p-6'>
+      <div className={cn(AdminCategoriesVariants({}), className)} {...props}>
         <div className='max-w-7xl mx-auto'>
           <div className='flex items-center justify-center h-64'>
             <div className='text-center'>
@@ -82,7 +99,10 @@ export function AdminCategories() {
   }
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-slate-900 dark:via-slate-800 dark:to-purple-900 p-6'>
+    <div
+      className={cn(AdminCategoriesVariants({}), className)}
+      {...props}
+    >
       <div className='max-w-7xl mx-auto space-y-8'>
         {/* 헤더 */}
         <Card>
@@ -98,7 +118,7 @@ export function AdminCategories() {
                 </CardDescription>
               </div>
               <Button
-                onClick={handleNewCategory}
+                onClick={onClickNewCategory}
                 className='flex items-center gap-2'
               >
                 <FiPlus className='w-5 h-5' />
@@ -115,14 +135,14 @@ export function AdminCategories() {
         {/* 카테고리 목록 */}
         <CategoryList
           categories={categories}
-          onEditCategory={handleEditCategory}
+          onEditCategory={onClickEditCategory}
         />
 
         {/* 카테고리 폼 모달 */}
         <CategoryForm
           category={editingCategory}
           open={showForm}
-          onClose={handleCloseForm}
+          onClose={onCloseCategoryForm}
         />
       </div>
     </div>

--- a/app/(admin)/admin/categories/page.tsx
+++ b/app/(admin)/admin/categories/page.tsx
@@ -11,7 +11,7 @@ interface Props {
   children?: React.ReactNode;
 }
 
-export default function AdminCategoriesPage({ children, }: Props) {
+export function AdminCategoriesPage({ children, }: Props) {
   return (
     <AdminCategories />
   );

--- a/app/(admin)/admin/hashtags/_components/AdminHashtags.tsx
+++ b/app/(admin)/admin/hashtags/_components/AdminHashtags.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { FiPlus, FiHash } from 'react-icons/fi';
 
+import { cva, type VariantProps } from 'class-variance-authority';
 import { HashtagForm } from './HashtagForm';
 import { HashtagList } from './HashtagList';
 import { HashtagStatistics } from './HashtagStatistics';
@@ -11,13 +12,29 @@ import { HashtagStatistics } from './HashtagStatistics';
 import { Button } from '@/(common)/_components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/(common)/_components/ui/card';
 import { HashtagsApi } from '@/_entities/hashtags';
+import { cn } from '@/_libs';
 import type { Hashtag } from '@/_prisma/client';
 
 interface HashtagWithCount extends Hashtag {
   post_count: number;
 }
 
-export function AdminHashtags() {
+const AdminHashtagsVariants = cva(
+  [
+    'min-h-screen bg-gradient-to-br from-emerald-50 via-white to-teal-50 dark:from-slate-900 dark:via-slate-800 dark:to-emerald-900 p-6',
+  ],
+  {
+    variants: {},
+    defaultVariants: {},
+    compoundVariants: [],
+  }
+);
+
+interface AdminHashtagsProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof AdminHashtagsVariants> {}
+
+export function AdminHashtags({ className, ...props }: AdminHashtagsProps) {
   const [ showForm, setShowForm, ] = useState(false);
   const [ editingHashtag, setEditingHashtag, ] = useState<HashtagWithCount | null>(null);
 
@@ -32,24 +49,24 @@ export function AdminHashtags() {
 
   const hashtags = (hashtagsResponse?.response || []) as HashtagWithCount[];
 
-  const handleNewHashtag = () => {
+  const onClickNewHashtag = () => {
     setEditingHashtag(null);
     setShowForm(true);
   };
 
-  const handleEditHashtag = (hashtag: HashtagWithCount) => {
+  const onClickEditHashtag = (hashtag: HashtagWithCount) => {
     setEditingHashtag(hashtag);
     setShowForm(true);
   };
 
-  const handleCloseForm = () => {
+  const onCloseHashtagForm = () => {
     setShowForm(false);
     setEditingHashtag(null);
   };
 
   if (isLoading) {
     return (
-      <div className='min-h-screen bg-gradient-to-br from-emerald-50 via-white to-teal-50 dark:from-slate-900 dark:via-slate-800 dark:to-emerald-900 p-6'>
+      <div className={cn(AdminHashtagsVariants({}), className)} {...props}>
         <div className='max-w-7xl mx-auto'>
           <div className='flex items-center justify-center h-64'>
             <div className='text-center'>
@@ -64,7 +81,7 @@ export function AdminHashtags() {
 
   if (error) {
     return (
-      <div className='min-h-screen bg-gradient-to-br from-emerald-50 via-white to-teal-50 dark:from-slate-900 dark:via-slate-800 dark:to-emerald-900 p-6'>
+      <div className={cn(AdminHashtagsVariants({}), className)} {...props}>
         <div className='max-w-7xl mx-auto'>
           <div className='flex items-center justify-center h-64'>
             <div className='text-center'>
@@ -83,7 +100,10 @@ export function AdminHashtags() {
   }
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-emerald-50 via-white to-teal-50 dark:from-slate-900 dark:via-slate-800 dark:to-emerald-900 p-6'>
+    <div
+      className={cn(AdminHashtagsVariants({}), className)}
+      {...props}
+    >
       <div className='max-w-7xl mx-auto space-y-8'>
         {/* 헤더 */}
         <Card>
@@ -99,7 +119,7 @@ export function AdminHashtags() {
                 </CardDescription>
               </div>
               <Button
-                onClick={handleNewHashtag}
+                onClick={onClickNewHashtag}
                 className='flex items-center gap-2'
               >
                 <FiPlus className='w-5 h-5' />
@@ -116,14 +136,14 @@ export function AdminHashtags() {
         {/* 해시태그 목록 */}
         <HashtagList
           hashtags={hashtags}
-          onEditHashtag={handleEditHashtag}
+          onEditHashtag={onClickEditHashtag}
         />
 
         {/* 해시태그 폼 모달 */}
         <HashtagForm
           hashtag={editingHashtag}
           open={showForm}
-          onClose={handleCloseForm}
+          onClose={onCloseHashtagForm}
         />
       </div>
     </div>

--- a/app/(admin)/admin/hashtags/page.tsx
+++ b/app/(admin)/admin/hashtags/page.tsx
@@ -11,7 +11,7 @@ interface Props {
   children?: React.ReactNode;
 }
 
-export default function AdminHashtagsPage({ children, }: Props) {
+export function AdminHashtagsPage({ children, }: Props) {
   return (
     <AdminHashtags />
   );

--- a/app/(admin)/admin/page.tsx
+++ b/app/(admin)/admin/page.tsx
@@ -11,7 +11,7 @@ interface Props {
   children?: React.ReactNode;
 }
 
-export default function AdminDashboardPage({ children, }: Props) {
+export function AdminDashboardPage({ children, }: Props) {
   return (
     <AdminDashboard />
   );

--- a/app/(admin)/admin/posts/_components/AdminPosts.tsx
+++ b/app/(admin)/admin/posts/_components/AdminPosts.tsx
@@ -1,8 +1,32 @@
-'use client';
+﻿'use client';
 
-export function AdminPosts() {
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/_libs';
+
+const AdminPostsVariants = cva(
+  [
+    'admin-posts',
+  ],
+  {
+    variants: {},
+    defaultVariants: {},
+    compoundVariants: [],
+  }
+);
+
+interface AdminPostsProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof AdminPostsVariants> {}
+
+export function AdminPosts({ className, ...props }: AdminPostsProps) {
   return (
-    <div className='admin-posts'>
+    <div
+      className={cn(
+        AdminPostsVariants({}),
+        className,
+      )}
+      {...props}
+    >
       <h1>포스트 관리</h1>
       <p>블로그 포스트를 관리할 수 있습니다.</p>
     </div>

--- a/app/(admin)/admin/posts/new/_components/NewPost.tsx
+++ b/app/(admin)/admin/posts/new/_components/NewPost.tsx
@@ -4,12 +4,29 @@ import { useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+import { cva, type VariantProps } from 'class-variance-authority';
 import { MarkdownEditor } from '@/(admin)/_components';
 import { Button } from '@/(common)/_components/ui/button';
 import { Input } from '@/(common)/_components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/(common)/_components/ui/select';
 import { useCreatePost, PostStatus } from '@/_entities/posts';
+import { cn } from '@/_libs';
 import type { PostFormData } from '@/_entities/posts';
+
+const NewPostVariants = cva(
+  [
+    'space-y-6',
+  ],
+  {
+    variants: {},
+    defaultVariants: {},
+    compoundVariants: [],
+  }
+);
+
+interface NewPostProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof NewPostVariants> {}
 
 // 기본 validation 함수
 const validateForm = (data: PostFormData) => {
@@ -44,7 +61,7 @@ const subcategories = [
   { id: '3', name: 'React', slug: 'react', category_id: '1', },
 ];
 
-export function NewPost() {
+export function NewPost({ className, ...props }: NewPostProps) {
   const router = useRouter();
 
   const [ hashtagInput, setHashtagInput, ] = useState('');
@@ -88,7 +105,7 @@ export function NewPost() {
   const createPostMutation = useCreatePost();
 
   // 해시태그 관련 함수들
-  const handleHashtagKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const onKeyPressHashtagInput = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && hashtagInput.trim()) {
       e.preventDefault();
       const newHashtag = hashtagInput.trim();
@@ -101,13 +118,13 @@ export function NewPost() {
     }
   };
 
-  const removeHashtag = (indexToRemove: number) => {
+  const onClickRemoveHashtag = (indexToRemove: number) => {
     const updatedHashtags = currentHashtags.filter((_, index) => index !== indexToRemove);
     setValue('hashtags', updatedHashtags);
   };
 
   // 폼 제출 함수들
-  const handleSaveDraft = handleSubmit(async (data) => {
+  const onClickSaveDraft = handleSubmit(async (data) => {
     try {
       const formData = data as PostFormData;
       const validationErrors = validateForm(formData);
@@ -129,7 +146,7 @@ export function NewPost() {
     }
   });
 
-  const handlePublish = handleSubmit(async (data) => {
+  const onClickPublish = handleSubmit(async (data) => {
     try {
       const formData = data as PostFormData;
       const validationErrors = validateForm(formData);
@@ -153,7 +170,13 @@ export function NewPost() {
   });
 
   return (
-    <div className='space-y-6'>
+    <div
+      className={cn(
+        NewPostVariants({}),
+        className,
+      )}
+      {...props}
+    >
       {/* Page Header */}
       <div className='flex items-center justify-between'>
         <h1 className='text-2xl font-bold text-gray-900'>새 포스트 작성</h1>
@@ -161,14 +184,14 @@ export function NewPost() {
         <div className='flex space-x-3'>
           <Button
             variant='outline'
-            onClick={handleSaveDraft}
+            onClick={onClickSaveDraft}
             disabled={isSubmitting || createPostMutation.isPending}
           >
             임시 저장
           </Button>
 
           <Button
-            onClick={handlePublish}
+            onClick={onClickPublish}
             disabled={isSubmitting || createPostMutation.isPending}
           >
             발행하기
@@ -268,7 +291,7 @@ export function NewPost() {
               type='text'
               value={hashtagInput}
               onChange={(e) => setHashtagInput(e.target.value)}
-              onKeyPress={handleHashtagKeyPress}
+              onKeyPress={onKeyPressHashtagInput}
               placeholder='해시태그를 입력하고 Enter를 누르세요'
             />
 
@@ -283,7 +306,7 @@ export function NewPost() {
                     #{tag}
                     <button
                       type='button'
-                      onClick={() => removeHashtag(index)}
+                      onClick={() => onClickRemoveHashtag(index)}
                       className='ml-1 text-blue-600 hover:text-blue-800 focus:outline-none'
                     >
                       ×

--- a/app/(admin)/admin/posts/new/page.tsx
+++ b/app/(admin)/admin/posts/new/page.tsx
@@ -10,7 +10,7 @@ interface Props {
   children?: React.ReactNode;
 }
 
-export default function NewPostPage({ children, }: Props) {
+export function NewPostPage({ children, }: Props) {
   return (
     <NewPost />
   );

--- a/app/(admin)/admin/posts/page.tsx
+++ b/app/(admin)/admin/posts/page.tsx
@@ -11,7 +11,7 @@ interface Props {
   children?: React.ReactNode;
 }
 
-export default function AdminPostsPage({ children, }: Props) {
+export function AdminPostsPage({ children, }: Props) {
   return (
     <AdminPosts />
   );

--- a/app/(admin)/admin/profile/_components/AdminProfile.tsx
+++ b/app/(admin)/admin/profile/_components/AdminProfile.tsx
@@ -3,15 +3,32 @@
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FiUser, FiLock, FiSave, FiEdit } from 'react-icons/fi';
+import { cva, type VariantProps } from 'class-variance-authority';
 
 import { Button } from '@/(common)/_components/ui/button';
 import { Card } from '@/(common)/_components/ui/card';
 import { Input } from '@/(common)/_components/ui/input';
 import { Label } from '@/(common)/_components/ui/label';
+import { cn } from '@/_libs';
 import { useGetAdminProfile, useUpdateAdminProfile, useChangeAdminPassword } from '@/_entities/users';
 import type { AdminProfileUpdateRequest, AdminPasswordChangeRequest } from '@/_entities/users';
 
-export function AdminProfile() {
+const AdminProfileVariants = cva(
+  [
+    'space-y-6',
+  ],
+  {
+    variants: {},
+    defaultVariants: {},
+    compoundVariants: [],
+  }
+);
+
+interface AdminProfileProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof AdminProfileVariants> {}
+
+export function AdminProfile({ className, ...props }: AdminProfileProps) {
   const [ isEditingProfile, setIsEditingProfile, ] = useState(false);
   const [ isChangingPassword, setIsChangingPassword, ] = useState(false);
 
@@ -45,7 +62,7 @@ export function AdminProfile() {
     }
   }, [ profile, profileForm, ]);
 
-  const handleUpdateProfile = (data: AdminProfileUpdateRequest) => {
+  const onSubmitUpdateProfile = (data: AdminProfileUpdateRequest) => {
     updateProfileMutation.mutate(data, {
       onSuccess: () => {
         setIsEditingProfile(false);
@@ -57,7 +74,7 @@ export function AdminProfile() {
     });
   };
 
-  const handleChangePassword = (data: AdminPasswordChangeRequest) => {
+  const onSubmitChangePassword = (data: AdminPasswordChangeRequest) => {
     changePasswordMutation.mutate(data, {
       onSuccess: () => {
         setIsChangingPassword(false);
@@ -95,7 +112,10 @@ export function AdminProfile() {
   }
 
   return (
-    <div className='space-y-6'>
+    <div
+      className={cn(AdminProfileVariants({}), className)}
+      {...props}
+    >
       <div className='flex items-center justify-between'>
         <div>
           <h1 className='text-2xl font-bold text-gray-900 dark:text-gray-100'>관리자 프로필</h1>
@@ -110,7 +130,7 @@ export function AdminProfile() {
           <h2 className='text-lg font-semibold text-gray-900 dark:text-gray-100'>프로필 정보</h2>
         </div>
 
-        <form onSubmit={profileForm.handleSubmit(handleUpdateProfile)} className='space-y-4'>
+        <form onSubmit={profileForm.handleSubmit(onSubmitUpdateProfile)} className='space-y-4'>
           <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
             <div>
               <Label htmlFor='name'>이름</Label>
@@ -212,7 +232,7 @@ export function AdminProfile() {
             </Button>
           </div>
         ) : (
-          <form onSubmit={passwordForm.handleSubmit(handleChangePassword)} className='space-y-4'>
+          <form onSubmit={passwordForm.handleSubmit(onSubmitChangePassword)} className='space-y-4'>
             <div>
               <Label htmlFor='currentPassword'>현재 비밀번호</Label>
               <Input

--- a/app/(admin)/admin/profile/page.tsx
+++ b/app/(admin)/admin/profile/page.tsx
@@ -11,7 +11,7 @@ interface Props {
   children?: React.ReactNode;
 }
 
-export default function AdminProfilePage({ children, }: Props) {
+export function AdminProfilePage({ children, }: Props) {
   return (
     <AdminProfile />
   );


### PR DESCRIPTION
## Summary
- refactor admin dashboard page and components to use CVA and named exports
- apply CVA styles to admin posts, categories, hashtags, profile, and new post components
- rename event handlers following on<EventType> pattern
- convert admin page exports to named functions

## Testing
- `pnpm lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847d2edc7f0832a91fd37509538bda6