### PR TITLE
Fix page metadata

### DIFF
--- a/app/(admin)/admin/categories/page.tsx
+++ b/app/(admin)/admin/categories/page.tsx
@@ -11,7 +11,7 @@ interface Props {
   children?: React.ReactNode;
 }
 
-export function AdminCategoriesPage({ children, }: Props) {
+export default function AdminCategoriesPage({ children, }: Props) {
   return (
     <AdminCategories />
   );

--- a/app/(admin)/admin/hashtags/page.tsx
+++ b/app/(admin)/admin/hashtags/page.tsx
@@ -11,7 +11,7 @@ interface Props {
   children?: React.ReactNode;
 }
 
-export function AdminHashtagsPage({ children, }: Props) {
+export default function AdminHashtagsPage({ children, }: Props) {
   return (
     <AdminHashtags />
   );

--- a/app/(admin)/admin/posts/[id]/edit/page.tsx
+++ b/app/(admin)/admin/posts/[id]/edit/page.tsx
@@ -1,5 +1,4 @@
 import { EditPost } from './_components';
-
 import { setMeta } from '@/_libs';
 
 interface Props {
@@ -15,7 +14,6 @@ export async function generateMetadata({ params, }: Props) {
     description: '블로그 포스트를 수정합니다.',
   });
 }
-
 interface PageProps {
   params: Promise<{ id: string }>;
   children?: React.ReactNode;

--- a/app/(admin)/admin/posts/new/page.tsx
+++ b/app/(admin)/admin/posts/new/page.tsx
@@ -1,5 +1,4 @@
 import { NewPost } from './_components';
-
 import { setMeta } from '@/_libs';
 
 interface Props {
@@ -10,6 +9,7 @@ export const metadata = setMeta({
   title: '새 포스트 작성',
   url: '/admin/posts/new',
 });
+
 
 export default function NewPostPage({ children, }: Props) {
   return (

--- a/app/(admin)/admin/posts/page.tsx
+++ b/app/(admin)/admin/posts/page.tsx
@@ -1,5 +1,4 @@
 import { AdminPosts } from './_components';
-
 import { setMeta } from '@/_libs';
 
 export const metadata = setMeta({
@@ -7,6 +6,7 @@ export const metadata = setMeta({
   url: '/admin/posts',
   description: '블로그 포스트를 관리할 수 있습니다.',
 });
+
 
 interface Props {
   children?: React.ReactNode;

--- a/app/(admin)/admin/profile/page.tsx
+++ b/app/(admin)/admin/profile/page.tsx
@@ -11,7 +11,7 @@ interface Props {
   children?: React.ReactNode;
 }
 
-export function AdminProfilePage({ children, }: Props) {
+export default function AdminProfilePage({ children, }: Props) {
   return (
     <AdminProfile />
   );

--- a/app/(common)/page.tsx
+++ b/app/(common)/page.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { Home } from './_components';
-
 import { setMeta } from '@/_libs';
 
 export const metadata = setMeta({


### PR DESCRIPTION
## Summary
- restore metadata exports for page components
- keep default exports for page components

## Testing
- `pnpm lint` *(fails: 10046 errors, 21241 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6848dde8f3f8832aa62e33967c8a3413