### PR TITLE
Refactor entity APIs to use centralized response types

### DIFF
--- a/app/_entities/categories/categories.api.ts
+++ b/app/_entities/categories/categories.api.ts
@@ -1,7 +1,11 @@
 import type {
   CreateCategory,
   UpdateCategory,
-  CategoryEx
+  CategoryEx,
+  CategoriesResponse,
+  CategoryResponse,
+  CategoryPostsResponse,
+  DeleteCategoryResponse
 } from './categories.types';
 
 import { Api } from '@/_libs';
@@ -10,32 +14,17 @@ import type { Category } from '@/_prisma/client';
 export class CategoriesApi {
   // 모든 카테고리 조회
   static async getAll() {
-    return Api.getQuery<{
-      message: string;
-      response: (Category & {
-        post_count: number;
-        published_post_count: number;
-      })[];
-        }>('/categories');
+    return Api.getQuery<CategoriesResponse>('/categories');
   }
 
   // 개별 카테고리 조회 (ID)
   static async getById(id: string) {
-    return Api.getQuery<{
-      message: string;
-      response: Category;
-    }>(`/categories/${id}`);
+    return Api.getQuery<CategoryResponse>(`/categories/${id}`);
   }
 
   // 카테고리 생성
   static async create(data: CreateCategory) {
-    return Api.postQuery<
-      {
-        message: string;
-        response: Category;
-      },
-      CreateCategory
-    >(
+    return Api.postQuery<CategoryResponse, CreateCategory>(
       '/categories',
       data
     );
@@ -46,13 +35,7 @@ export class CategoriesApi {
     id: string,
     data: UpdateCategory
   ) {
-    return Api.putQuery<
-      {
-        message: string;
-        response: Category;
-      },
-      UpdateCategory
-    >(
+    return Api.putQuery<CategoryResponse, UpdateCategory>(
       `/categories/${id}`,
       data
     );
@@ -60,17 +43,11 @@ export class CategoriesApi {
 
   // 카테고리 삭제
   static async delete(id: string) {
-    return Api.deleteQuery<{
-      message: string;
-      response: null;
-    }>(`/categories/${id}`);
+    return Api.deleteQuery<DeleteCategoryResponse>(`/categories/${id}`);
   }
 
   // 카테고리별 포스트 목록 조회
   static async getPostsByCategory(categoryId: string) {
-    return Api.getQuery<{
-      message: string;
-      response: any[];
-    }>(`/posts?category=${categoryId}`);
+    return Api.getQuery<CategoryPostsResponse>(`/posts?category=${categoryId}`);
   }
 }

--- a/app/_entities/categories/categories.types.ts
+++ b/app/_entities/categories/categories.types.ts
@@ -1,4 +1,5 @@
 import type { Category } from '@/_prisma/client';
+import type { ApiResponse } from '../common';
 
 // 카테고리 생성
 export interface CreateCategory {
@@ -24,3 +25,13 @@ export interface CategoryEx extends Category {
     status: string;
   }[];
 }
+
+export interface CategoryWithCounts extends Category {
+  post_count: number;
+  published_post_count: number;
+}
+
+export type CategoriesResponse = ApiResponse<CategoryWithCounts[]>;
+export type CategoryResponse = ApiResponse<Category>;
+export type DeleteCategoryResponse = ApiResponse<null>;
+export type CategoryPostsResponse = ApiResponse<any[]>;

--- a/app/_entities/categories/index.ts
+++ b/app/_entities/categories/index.ts
@@ -2,7 +2,11 @@
 export type {
   CreateCategory,
   UpdateCategory,
-  CategoryEx
+  CategoryEx,
+  CategoriesResponse,
+  CategoryResponse,
+  DeleteCategoryResponse,
+  CategoryPostsResponse
 } from './categories.types';
 
 // API exports

--- a/app/_entities/hashtags/hashtags.api.ts
+++ b/app/_entities/hashtags/hashtags.api.ts
@@ -1,7 +1,13 @@
 import type {
   CreateHashtag,
   UpdateHashtag,
-  HashtagEx
+  HashtagEx,
+  HashtagsResponse,
+  HashtagResponse,
+  CreateHashtagResponse,
+  UpdateHashtagResponse,
+  DeleteHashtagResponse,
+  HashtagPostsResponse
 } from './hashtags.types';
 
 import { Api } from '@/_libs';
@@ -17,43 +23,22 @@ export class HashtagsApi {
     const queryString = params.toString();
     const url = queryString ? `/hashtags?${queryString}` : '/hashtags';
 
-    return Api.getQuery<{
-      message: string;
-      response: (Hashtag & {
-        post_count: number;
-      })[];
-        }>(url);
+    return Api.getQuery<HashtagsResponse>(url);
   }
 
   // 개별 해시태그 조회 (ID) - slug API 사용
   static async getById(id: string) {
-    return Api.getQuery<{
-      message: string;
-      response: Hashtag & {
-        post_count: number;
-      };
-    }>(`/hashtags/${id}`);
+    return Api.getQuery<HashtagResponse>(`/hashtags/${id}`);
   }
 
   // 개별 해시태그 조회 (Slug)
   static async getBySlug(slug: string) {
-    return Api.getQuery<{
-      message: string;
-      response: Hashtag & {
-        post_count: number;
-      };
-    }>(`/hashtags/${slug}`);
+    return Api.getQuery<HashtagResponse>(`/hashtags/${slug}`);
   }
 
   // 해시태그 생성
   static async create(data: CreateHashtag) {
-    return Api.postQuery<
-      {
-        message: string;
-        response: Hashtag;
-      },
-      CreateHashtag
-    >(
+    return Api.postQuery<CreateHashtagResponse, CreateHashtag>(
       '/hashtags',
       data
     );
@@ -64,13 +49,7 @@ export class HashtagsApi {
     id: string,
     data: UpdateHashtag
   ) {
-    return Api.putQuery<
-      {
-        message: string;
-        response: Hashtag;
-      },
-      UpdateHashtag
-    >(
+    return Api.putQuery<UpdateHashtagResponse, UpdateHashtag>(
       `/hashtags/${id}`,
       data
     );
@@ -78,10 +57,7 @@ export class HashtagsApi {
 
   // 해시태그 삭제 - slug API 사용 (id도 처리 가능)
   static async delete(id: string) {
-    return Api.deleteQuery<{
-      message: string;
-      response: null;
-    }>(`/hashtags/${id}`);
+    return Api.deleteQuery<DeleteHashtagResponse>(`/hashtags/${id}`);
   }
 
   // 해시태그별 포스트 목록 조회
@@ -101,20 +77,7 @@ export class HashtagsApi {
       ? `/hashtags/${slug}/posts?${queryString}`
       : `/hashtags/${slug}/posts`;
 
-    return Api.getQuery<{
-      message: string;
-      response: {
-        hashtag: {
-          id: string;
-          name: string;
-          slug: string;
-        };
-        posts: any[];
-        total: number;
-        page: number;
-        limit: number;
-      };
-    }>(url);
+    return Api.getQuery<HashtagPostsResponse>(url);
   }
 
   // 자동완성을 위한 검색 (제한된 수량)

--- a/app/_entities/hashtags/hashtags.types.ts
+++ b/app/_entities/hashtags/hashtags.types.ts
@@ -1,4 +1,5 @@
 import type { Hashtag } from '@/_prisma/client';
+import type { ApiResponse } from '../common';
 
 // 해시태그 생성
 export interface CreateHashtag {
@@ -18,3 +19,28 @@ export interface HashtagEx extends Hashtag {
     post_id: string;
   }[];
 }
+
+export interface HashtagWithCount extends Hashtag {
+  post_count: number;
+}
+
+export type HashtagsResponse = ApiResponse<HashtagWithCount[]>;
+export type HashtagResponse = ApiResponse<HashtagWithCount>;
+export type CreateHashtagResponse = ApiResponse<Hashtag>;
+export type UpdateHashtagResponse = ApiResponse<Hashtag>;
+export type DeleteHashtagResponse = ApiResponse<null>;
+
+export interface HashtagPostsData {
+  hashtag: {
+    id: string;
+    name: string;
+    slug: string;
+  };
+  posts: any[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export type HashtagPostsResponse = ApiResponse<HashtagPostsData>;
+

--- a/app/_entities/hashtags/index.ts
+++ b/app/_entities/hashtags/index.ts
@@ -2,7 +2,13 @@
 export type {
   CreateHashtag,
   UpdateHashtag,
-  HashtagEx
+  HashtagEx,
+  HashtagsResponse,
+  HashtagResponse,
+  CreateHashtagResponse,
+  UpdateHashtagResponse,
+  DeleteHashtagResponse,
+  HashtagPostsResponse
 } from './hashtags.types';
 
 // API exports

--- a/app/_entities/posts/index.ts
+++ b/app/_entities/posts/index.ts
@@ -11,7 +11,11 @@ export type {
   BatchOperation,
   PostStats,
   PostSortOption,
-  PostFiltersEx
+  PostFiltersEx,
+  BatchDeleteResponse,
+  BatchUpdateStatusResponse,
+  BatchUpdateRequest,
+  BatchUpdateChanges
 } from './posts.types';
 
 // Re-export PostStatus from Prisma client

--- a/app/_entities/posts/posts.api.ts
+++ b/app/_entities/posts/posts.api.ts
@@ -3,7 +3,11 @@ import type {
   PostFilters,
   PostsResponse,
   PostEx,
-  PostStats
+  PostStats,
+  BatchDeleteResponse,
+  BatchUpdateStatusResponse,
+  BatchUpdateRequest,
+  BatchUpdateChanges
 } from './posts.types';
 
 import { Api } from '@/_libs';
@@ -150,44 +154,25 @@ export class PostsApi {
 
   // 일괄 삭제
   static async batchDelete(postIds: string[]) {
-    return Api.deleteWithDataQuery<{
-      deleted_count: number;
-      deleted_posts: { id: string; title: string }[];
-      not_found_ids: string[];
-    }, { post_ids: string[] }>('/posts/batch', {
-      post_ids: postIds,
-    });
+    return Api.deleteWithDataQuery<BatchDeleteResponse, BatchUpdateRequest>(
+      '/posts/batch',
+      {
+        post_ids: postIds,
+      }
+    );
   }
 
   // 일괄 상태 변경
   static async batchUpdateStatus(
     postIds: string[],
-    updates: {
-      status?: string;
-      is_published?: boolean;
-    }
+    updates: BatchUpdateChanges
   ) {
-    return Api.patchQuery<{
-      updated_count: number;
-      updated_posts: {
-        id: string;
-        title: string;
-        status: string;
-        is_published: boolean;
-        updated_at: string;
-      }[];
-      not_found_ids: string[];
-      changes: {
-        status?: string;
-        is_published?: boolean;
-      };
-    }, {
-      post_ids: string[];
-      status?: string;
-      is_published?: boolean;
-    }>('/posts/batch-status', {
-      post_ids: postIds,
-      ...updates,
-    });
+    return Api.patchQuery<BatchUpdateStatusResponse, BatchUpdateRequest>(
+      '/posts/batch-status',
+      {
+        post_ids: postIds,
+        ...updates,
+      }
+    );
   }
 }

--- a/app/_entities/posts/posts.types.ts
+++ b/app/_entities/posts/posts.types.ts
@@ -1,4 +1,5 @@
 import type { Post, PostStatus } from '@/_prisma/client';
+import type { ApiResponse } from '../common';
 
 // 포스트 생성
 export interface CreatePost {
@@ -131,3 +132,40 @@ export interface PostFiltersEx extends PostFilters {
   date_from?: string;
   date_to?: string;
 }
+
+export interface BatchDeleteResponseData {
+  deleted_count: number;
+  deleted_posts: { id: string; title: string }[];
+  not_found_ids: string[];
+}
+
+export type BatchDeleteResponse = ApiResponse<BatchDeleteResponseData>;
+
+export interface UpdatedPostInfo {
+  id: string;
+  title: string;
+  status: string;
+  is_published: boolean;
+  updated_at: string;
+}
+
+export interface BatchUpdateChanges {
+  status?: string;
+  is_published?: boolean;
+}
+
+export interface BatchUpdateResponseData {
+  updated_count: number;
+  updated_posts: UpdatedPostInfo[];
+  not_found_ids: string[];
+  changes: BatchUpdateChanges;
+}
+
+export interface BatchUpdateRequest {
+  post_ids: string[];
+  status?: string;
+  is_published?: boolean;
+}
+
+export type BatchUpdateStatusResponse = ApiResponse<BatchUpdateResponseData>;
+

--- a/app/_entities/subcategories/index.ts
+++ b/app/_entities/subcategories/index.ts
@@ -2,7 +2,10 @@
 export type {
   CreateSubcategory,
   UpdateSubcategory,
-  SubcategoryEx
+  SubcategoryEx,
+  SubcategoriesResponse,
+  SubcategoryResponse,
+  DeleteSubcategoryResponse
 } from './subcategories.types';
 
 // API exports

--- a/app/_entities/subcategories/subcategories.api.ts
+++ b/app/_entities/subcategories/subcategories.api.ts
@@ -1,4 +1,11 @@
-import type { CreateSubcategory, UpdateSubcategory, SubcategoryEx } from './subcategories.types';
+import type {
+  CreateSubcategory,
+  UpdateSubcategory,
+  SubcategoryEx,
+  SubcategoriesResponse,
+  SubcategoryResponse,
+  DeleteSubcategoryResponse
+} from './subcategories.types';
 
 import { Api } from '@/_libs';
 
@@ -6,20 +13,11 @@ export class SubcategoriesApi {
 
   static async getSubcategories(categoryId?: string) {
     const params = categoryId ? `?category_id=${categoryId}` : '';
-    return Api.getQuery<{
-      message: string;
-      response: SubcategoryEx[];
-    }>(`/subcategories${params}`);
+    return Api.getQuery<SubcategoriesResponse>(`/subcategories${params}`);
   }
 
   static async createSubcategory(data: CreateSubcategory) {
-    return Api.postQuery<
-      {
-        message: string;
-        response: SubcategoryEx;
-      },
-      CreateSubcategory
-    >(
+    return Api.postQuery<SubcategoryResponse, CreateSubcategory>(
       '/subcategories',
       data
     );
@@ -29,23 +27,14 @@ export class SubcategoriesApi {
     id: string,
     data: UpdateSubcategory
   ) {
-    return Api.putQuery<
-      {
-        message: string;
-        response: SubcategoryEx;
-      },
-      UpdateSubcategory
-    >(
+    return Api.putQuery<SubcategoryResponse, UpdateSubcategory>(
       `/subcategories/${id}`,
       data
     );
   }
 
   static async deleteSubcategory(id: string) {
-    return Api.deleteQuery<{
-      message: string;
-      response: null;
-    }>(`/subcategories/${id}`);
+    return Api.deleteQuery<DeleteSubcategoryResponse>(`/subcategories/${id}`);
   }
 
 }

--- a/app/_entities/subcategories/subcategories.types.ts
+++ b/app/_entities/subcategories/subcategories.types.ts
@@ -1,4 +1,5 @@
 import type { Subcategory } from '@/_prisma/client';
+import type { ApiResponse } from '../common';
 
 // 서브카테고리 생성
 export interface CreateSubcategory {
@@ -27,3 +28,7 @@ export interface SubcategoryEx extends Subcategory {
     posts: number;
   };
 }
+
+export type SubcategoriesResponse = ApiResponse<SubcategoryEx[]>;
+export type SubcategoryResponse = ApiResponse<SubcategoryEx>;
+export type DeleteSubcategoryResponse = ApiResponse<null>;


### PR DESCRIPTION
## Summary
- centralize API response interfaces in each entity's `types.ts`
- refactor `categories.api.ts` and `subcategories.api.ts` to consume new types
- refactor `hashtags.api.ts` to use exported response types
- refactor `posts.api.ts` batch operations with typed requests and responses
- expose new types from entity `index.ts` files

## Testing
- `pnpm lint` *(fails: 10047 errors, 21273 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68493656f328832a8f35fc94a3268283