### PR TITLE
Refactor JWT auth into reusable helper

### DIFF
--- a/app/api/_libs/index.ts
+++ b/app/api/_libs/index.ts
@@ -16,3 +16,5 @@ export {
   createSecurityErrorResponse,
   createSecureResponse
 } from './middleware';
+
+export { jwtAuth } from "./jwtAuth";

--- a/app/api/_libs/jwtAuth.ts
+++ b/app/api/_libs/jwtAuth.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import type { UserSession } from '@/_entities/user-auth';
+import { authenticate } from '@/api/_libs/middleware';
+
+export interface JwtAuthResult {
+  user?: UserSession;
+  response?: NextResponse;
+}
+
+export async function jwtAuth(
+  request: NextRequest,
+  strict: boolean = true
+): Promise<JwtAuthResult> {
+  const result = await authenticate(request);
+
+  if (!result.success) {
+    if (!strict) {
+      return {};
+    }
+
+    const response = NextResponse.json(
+      {
+        message: result.error!,
+        response: null,
+      },
+      {
+        status: result.status!,
+      }
+    );
+
+    return { response };
+  }
+
+  return { user: result.user };
+}

--- a/app/api/admin/profile/route.ts
+++ b/app/api/admin/profile/route.ts
@@ -1,44 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import type { UpdateUser } from '@/_entities/users';
-import { DB } from '@/api/_libs';
-import { serverTools } from '@/api/_libs/tools';
+import { DB, jwtAuth } from '@/api/_libs';
 
 // GET /api/admin/profile - 관리자 정보 조회
 export async function GET(req: NextRequest) {
   try {
     // JWT 인증
-    const cookie = req.cookies.get('accessToken');
-    if (!cookie) {
-      return NextResponse.json(
-        {
-          message: '인증 정보가 없습니다.',
-          response: null,
-        },
-        { status: 401, }
-      );
+    const authResult = await jwtAuth(req);
+    if (authResult.response) {
+      return authResult.response;
     }
 
-    if (!serverTools.jwt) {
-      return NextResponse.json(
-        {
-          message: '인증 시스템 오류가 발생했습니다.',
-          response: null,
-        },
-        { status: 500, }
-      );
-    }
-
-    const tokenData = await serverTools.jwt.tokenInfo('accessToken', cookie.value);
-    if (!tokenData || !tokenData.id) {
-      return NextResponse.json(
-        {
-          message: '관리자 권한이 없습니다.',
-          response: null,
-        },
-        { status: 403, }
-      );
-    }
+    const tokenData = authResult.user!;
 
     // 관리자 정보 조회
     const user = await DB.user().findUnique({
@@ -84,37 +58,12 @@ export async function GET(req: NextRequest) {
 export async function PUT(req: NextRequest) {
   try {
     // JWT 인증
-    const cookie = req.cookies.get('accessToken');
-    if (!cookie) {
-      return NextResponse.json(
-        {
-          message: '인증 정보가 없습니다.',
-          response: null,
-        },
-        { status: 401, }
-      );
+    const authResult = await jwtAuth(req);
+    if (authResult.response) {
+      return authResult.response;
     }
 
-    if (!serverTools.jwt) {
-      return NextResponse.json(
-        {
-          message: '인증 시스템 오류가 발생했습니다.',
-          response: null,
-        },
-        { status: 500, }
-      );
-    }
-
-    const tokenData = await serverTools.jwt.tokenInfo('accessToken', cookie.value);
-    if (!tokenData || !tokenData.id) {
-      return NextResponse.json(
-        {
-          message: '관리자 권한이 없습니다.',
-          response: null,
-        },
-        { status: 403, }
-      );
-    }
+    const tokenData = authResult.user!;
 
     const body: UpdateUser = await req.json();
     if (!body.name || !body.email) {

--- a/app/api/categories/[id]/route.ts
+++ b/app/api/categories/[id]/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import type { UpdateCategory } from '@/_entities/categories';
-import { DB } from '@/api/_libs';
-import { serverTools } from '@/api/_libs/tools';
+import { DB, jwtAuth } from '@/api/_libs';
 
 interface Params {
   params: Promise<{ id: string }>;
@@ -14,36 +13,9 @@ export async function PUT(request: NextRequest, { params, }: Params) {
     const { id, } = await params;
 
     // JWT 인증
-    const cookie = request.cookies.get('accessToken');
-    if (!cookie) {
-      return NextResponse.json(
-        {
-          message: '인증 정보가 없습니다.',
-          response: null,
-        },
-        { status: 401, }
-      );
-    }
-
-    if (!serverTools.jwt) {
-      return NextResponse.json(
-        {
-          message: '인증 시스템 오류가 발생했습니다.',
-          response: null,
-        },
-        { status: 500, }
-      );
-    }
-
-    const tokenData = await serverTools.jwt.tokenInfo('accessToken', cookie.value);
-    if (!tokenData || !tokenData.id) {
-      return NextResponse.json(
-        {
-          message: '관리자 권한이 없습니다.',
-          response: null,
-        },
-        { status: 403, }
-      );
+    const authResult = await jwtAuth(request);
+    if (authResult.response) {
+      return authResult.response;
     }
 
     // 기존 카테고리 확인
@@ -141,36 +113,9 @@ export async function DELETE(request: NextRequest, { params, }: Params) {
     const { id, } = await params;
 
     // JWT 인증
-    const cookie = request.cookies.get('accessToken');
-    if (!cookie) {
-      return NextResponse.json(
-        {
-          message: '인증 정보가 없습니다.',
-          response: null,
-        },
-        { status: 401, }
-      );
-    }
-
-    if (!serverTools.jwt) {
-      return NextResponse.json(
-        {
-          message: '인증 시스템 오류가 발생했습니다.',
-          response: null,
-        },
-        { status: 500, }
-      );
-    }
-
-    const tokenData = await serverTools.jwt.tokenInfo('accessToken', cookie.value);
-    if (!tokenData || !tokenData.id) {
-      return NextResponse.json(
-        {
-          message: '관리자 권한이 없습니다.',
-          response: null,
-        },
-        { status: 403, }
-      );
+    const authResult = await jwtAuth(request);
+    if (authResult.response) {
+      return authResult.response;
     }
 
     // 카테고리 존재 확인

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import type { CreateCategory } from '@/_entities/categories';
-import { DB } from '@/api/_libs';
-import { serverTools } from '@/api/_libs/tools';
+import { DB, jwtAuth } from '@/api/_libs';
 
 // GET /api/categories - 모든 카테고리 조회
 export async function GET() {
@@ -47,36 +46,9 @@ export async function GET() {
 export async function POST(req: NextRequest) {
   try {
     // JWT 인증
-    const cookie = req.cookies.get('accessToken');
-    if (!cookie) {
-      return NextResponse.json(
-        {
-          message: '인증 정보가 없습니다.',
-          response: null,
-        },
-        { status: 401, }
-      );
-    }
-
-    if (!serverTools.jwt) {
-      return NextResponse.json(
-        {
-          message: '인증 시스템 오류가 발생했습니다.',
-          response: null,
-        },
-        { status: 500, }
-      );
-    }
-
-    const tokenData = await serverTools.jwt.tokenInfo('accessToken', cookie.value);
-    if (!tokenData || !tokenData.id) {
-      return NextResponse.json(
-        {
-          message: '관리자 권한이 없습니다.',
-          response: null,
-        },
-        { status: 403, }
-      );
+    const authResult = await jwtAuth(req);
+    if (authResult.response) {
+      return authResult.response;
     }
 
     const body: CreateCategory = await req.json();

--- a/app/api/hashtags/[slug]/route.ts
+++ b/app/api/hashtags/[slug]/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import type { UpdateHashtag } from '@/_entities/hashtags';
-import { DB } from '@/api/_libs';
-import { serverTools } from '@/api/_libs/tools';
+import { DB, jwtAuth } from '@/api/_libs';
 
 interface Params {
   params: Promise<{ slug: string }>;
@@ -86,36 +85,9 @@ export async function PUT(request: NextRequest, { params, }: Params) {
     const { slug, } = await params;
 
     // JWT 인증
-    const cookie = request.cookies.get('accessToken');
-    if (!cookie) {
-      return NextResponse.json(
-        {
-          message: '인증 정보가 없습니다.',
-          response: null,
-        },
-        { status: 401, }
-      );
-    }
-
-    if (!serverTools.jwt) {
-      return NextResponse.json(
-        {
-          message: '인증 시스템 오류가 발생했습니다.',
-          response: null,
-        },
-        { status: 500, }
-      );
-    }
-
-    const tokenData = await serverTools.jwt.tokenInfo('accessToken', cookie.value);
-    if (!tokenData || !tokenData.id) {
-      return NextResponse.json(
-        {
-          message: '관리자 권한이 없습니다.',
-          response: null,
-        },
-        { status: 403, }
-      );
+    const authResult = await jwtAuth(request);
+    if (authResult.response) {
+      return authResult.response;
     }
 
     // UUID 형식이면 id로, 아니면 slug로 검색
@@ -214,36 +186,14 @@ export async function DELETE(request: NextRequest, { params, }: Params) {
     const { slug, } = await params;
 
     // JWT 인증
-    const cookie = request.cookies.get('accessToken');
-    if (!cookie) {
-      return NextResponse.json(
-        {
-          message: '인증 정보가 없습니다.',
-          response: null,
-        },
-        { status: 401, }
-      );
+    const authResult = await jwtAuth(request);
+    if (authResult.response) {
+      return authResult.response;
     }
 
-    if (!serverTools.jwt) {
-      return NextResponse.json(
-        {
-          message: '인증 시스템 오류가 발생했습니다.',
-          response: null,
-        },
-        { status: 500, }
-      );
-    }
-
-    const tokenData = await serverTools.jwt.tokenInfo('accessToken', cookie.value);
-    if (!tokenData || !tokenData.id) {
-      return NextResponse.json(
-        {
-          message: '관리자 권한이 없습니다.',
-          response: null,
-        },
-        { status: 403, }
-      );
+    const authResult = await jwtAuth(request);
+    if (authResult.response) {
+      return authResult.response;
     }
 
     // UUID 형식이면 id로, 아니면 slug로 검색

--- a/app/api/hashtags/route.ts
+++ b/app/api/hashtags/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import type { CreateHashtag } from '@/_entities/hashtags';
-import { DB } from '@/api/_libs';
-import { serverTools } from '@/api/_libs/tools';
+import { DB, jwtAuth } from '@/api/_libs';
 
 // GET /api/hashtags - 모든 해시태그 조회 (검색 및 자동완성 지원)
 export async function GET(req: NextRequest) {
@@ -68,36 +67,9 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   try {
     // JWT 인증
-    const cookie = req.cookies.get('accessToken');
-    if (!cookie) {
-      return NextResponse.json(
-        {
-          message: '인증 정보가 없습니다.',
-          response: null,
-        },
-        { status: 401, }
-      );
-    }
-
-    if (!serverTools.jwt) {
-      return NextResponse.json(
-        {
-          message: '인증 시스템 오류가 발생했습니다.',
-          response: null,
-        },
-        { status: 500, }
-      );
-    }
-
-    const tokenData = await serverTools.jwt.tokenInfo('accessToken', cookie.value);
-    if (!tokenData || !tokenData.id) {
-      return NextResponse.json(
-        {
-          message: '관리자 권한이 없습니다.',
-          response: null,
-        },
-        { status: 403, }
-      );
+    const authResult = await jwtAuth(req);
+    if (authResult.response) {
+      return authResult.response;
     }
 
     const body: CreateHashtag = await req.json();

--- a/app/api/posts/slug/[slug]/route.ts
+++ b/app/api/posts/slug/[slug]/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import type { ApiResponse, ApiError } from '@/_entities/common';
-import { DB } from '@/api/_libs';
-import { serverTools } from '@/api/_libs';
+import { DB, jwtAuth } from '@/api/_libs';
 
 interface Params {
 	params: Promise<{ slug: string }>;
@@ -66,17 +65,10 @@ export async function GET(request: NextRequest, { params, }: Params) {
 
     // 포스트 접근 권한 확인
     let isAdmin = false;
-    const cookie = request.cookies?.get('accessToken');
+    const authResult = await jwtAuth(request, false);
 
-    if (cookie && serverTools.jwt) {
-      try {
-        const tokenData = await serverTools.jwt.tokenInfo('accessToken', cookie.value);
-        if (tokenData && tokenData.id) {
-          isAdmin = true;
-        }
-      } catch (error) {
-        // 토큰이 유효하지 않아도 계속 진행 (일반 사용자로 처리)
-      }
+    if (authResult.user) {
+      isAdmin = true;
     }
 
     // 포스트 상태별 접근 제어

--- a/app/api/subcategories/[id]/route.ts
+++ b/app/api/subcategories/[id]/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import type { UpdateSubcategory } from '@/_entities/subcategories';
-import { DB } from '@/api/_libs';
-import { serverTools } from '@/api/_libs/tools';
+import { DB, jwtAuth } from '@/api/_libs';
 
 interface Params {
   params: Promise<{ id: string }>;
@@ -69,36 +68,9 @@ export async function GET(request: NextRequest, { params, }: Params) {
 // PUT /api/subcategories/[id] - 서브카테고리 수정 (Admin)
 export async function PUT(request: NextRequest, { params, }: Params) {
   try {
-    const cookie = request.cookies.get('accessToken');
-    if (!cookie) {
-      return NextResponse.json(
-        {
-          message: '인증 정보가 없습니다.',
-          response: null,
-        },
-        { status: 401, }
-      );
-    }
-
-    if (!serverTools.jwt) {
-      return NextResponse.json(
-        {
-          message: '인증 시스템 오류가 발생했습니다.',
-          response: null,
-        },
-        { status: 500, }
-      );
-    }
-
-    const tokenData = await serverTools.jwt.tokenInfo('accessToken', cookie.value);
-    if (!tokenData || !tokenData.id) {
-      return NextResponse.json(
-        {
-          message: '관리자 권한이 없습니다.',
-          response: null,
-        },
-        { status: 403, }
-      );
+    const authResult = await jwtAuth(request);
+    if (authResult.response) {
+      return authResult.response;
     }
 
     const { id, } = await params;
@@ -167,36 +139,9 @@ export async function PUT(request: NextRequest, { params, }: Params) {
 // DELETE /api/subcategories/[id] - 서브카테고리 삭제 (Admin)
 export async function DELETE(request: NextRequest, { params, }: Params) {
   try {
-    const cookie = request.cookies.get('accessToken');
-    if (!cookie) {
-      return NextResponse.json(
-        {
-          message: '인증 정보가 없습니다.',
-          response: null,
-        },
-        { status: 401, }
-      );
-    }
-
-    if (!serverTools.jwt) {
-      return NextResponse.json(
-        {
-          message: '인증 시스템 오류가 발생했습니다.',
-          response: null,
-        },
-        { status: 500, }
-      );
-    }
-
-    const tokenData = await serverTools.jwt.tokenInfo('accessToken', cookie.value);
-    if (!tokenData || !tokenData.id) {
-      return NextResponse.json(
-        {
-          message: '관리자 권한이 없습니다.',
-          response: null,
-        },
-        { status: 403, }
-      );
+    const authResult = await jwtAuth(request);
+    if (authResult.response) {
+      return authResult.response;
     }
 
     const { id, } = await params;

--- a/app/api/subcategories/route.ts
+++ b/app/api/subcategories/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import type { CreateSubcategory } from '@/_entities/subcategories';
-import { DB } from '@/api/_libs';
-import { serverTools } from '@/api/_libs/tools';
+import { DB, jwtAuth } from '@/api/_libs';
 
 // GET /api/subcategories - 서브카테고리 조회
 export async function GET(req: NextRequest) {
@@ -62,36 +61,9 @@ export async function GET(req: NextRequest) {
 // POST /api/subcategories - 새 서브카테고리 생성 (Admin)
 export async function POST(req: NextRequest) {
   try {
-    const cookie = req.cookies.get('accessToken');
-    if (!cookie) {
-      return NextResponse.json(
-        {
-          message: '인증 정보가 없습니다.',
-          response: null,
-        },
-        { status: 401, }
-      );
-    }
-
-    if (!serverTools.jwt) {
-      return NextResponse.json(
-        {
-          message: '인증 시스템 오류가 발생했습니다.',
-          response: null,
-        },
-        { status: 500, }
-      );
-    }
-
-    const tokenData = await serverTools.jwt.tokenInfo('accessToken', cookie.value);
-    if (!tokenData || !tokenData.id) {
-      return NextResponse.json(
-        {
-          message: '관리자 권한이 없습니다.',
-          response: null,
-        },
-        { status: 403, }
-      );
+    const authResult = await jwtAuth(req);
+    if (authResult.response) {
+      return authResult.response;
     }
 
     const body: CreateSubcategory = await req.json();


### PR DESCRIPTION
## Summary
- add jwtAuth helper to unify JWT authentication
- refactor category, hashtag, subcategory, post and admin routes to use the new helper
- export helper from API library

## Testing
- `pnpm lint` *(fails: 10082 errors, 21303 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684a65eaa8a4832a8aa0935a3027dc06