### PR TITLE
Implement role-based authorization

### DIFF
--- a/app/_entities/user-auth/user-auth.types.ts
+++ b/app/_entities/user-auth/user-auth.types.ts
@@ -1,3 +1,5 @@
+import type { UserRole } from "@/_prisma/client";
+
 // 토큰 정보
 export interface TokenInfo {
   token: string;
@@ -9,6 +11,7 @@ export interface TokenData {
   id: string;
   email: string;
   name: string;
+  role: UserRole;
   exp: number;
 }
 
@@ -35,6 +38,7 @@ export interface SignInResponse {
       id: string;
       email: string;
       name: string;
+      role: UserRole;
     };
     tokens: Tokens;
   };
@@ -68,6 +72,7 @@ export interface UserSession {
   id: string;
   email: string;
   name: string;
+  role: UserRole;
 }
 
 // 인증 상태

--- a/app/api/_libs/index.ts
+++ b/app/api/_libs/index.ts
@@ -6,6 +6,8 @@ export { performTokenRefresh } from './performRefresh';
 export {
   authenticate,
   createAuthResponse,
+  requireAuth,
+  requireRole,
   corsMiddleware,
   setCorsHeaders,
   setSecurityHeaders,

--- a/app/api/_libs/middleware/index.ts
+++ b/app/api/_libs/middleware/index.ts
@@ -1,4 +1,4 @@
-export { authenticate, createAuthResponse } from './auth';
+export { authenticate, createAuthResponse, requireAuth, requireRole } from './auth';
 export {
   corsMiddleware,
   setCorsHeaders,

--- a/app/api/_libs/tools/jwt.ts
+++ b/app/api/_libs/tools/jwt.ts
@@ -35,11 +35,11 @@ export class Jwt {
   // 토큰 생성
   public async genTokens(user: User): Promise<Tokens> {
     const {
-      id, email, name,
+      id, email, name, role,
     } = user;
 
     const tokenPayload = {
-      id, email, name,
+      id, email, name, role,
     };
 
     const accessTokenSecret = await this.setSecret(process.env.NEXT_PUBLIC_ACCESS_TOKEN_SECRET);

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -46,6 +46,7 @@ export async function GET(_request: NextRequest) {
         id: true,
         name: true,
         email: true,
+        role: true,
         created_at: true,
       },
     });
@@ -140,6 +141,12 @@ export async function POST(_request: NextRequest) {
     // 사용자 계정 확인
     const findUser = await DB.user().findUnique({
       where: { id: tokenData.id, },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+      },
     });
 
     if (!findUser) {
@@ -185,6 +192,7 @@ export async function POST(_request: NextRequest) {
           id: findUser.id,
           email: findUser.email,
           name: findUser.name,
+          role: findUser.role,
         },
       },
       { status: 200, }

--- a/app/api/auth/sign_in/route.ts
+++ b/app/api/auth/sign_in/route.ts
@@ -101,6 +101,7 @@ export async function POST(request: NextRequest) {
         id: findUser.id,
         email: findUser.email,
         name: findUser.name,
+        role: findUser.role,
       },
     };
 

--- a/docs/ROLE_AUTH_GUIDE.md
+++ b/docs/ROLE_AUTH_GUIDE.md
@@ -1,0 +1,26 @@
+# 권한 기반 인증 변경 사항
+
+이 문서는 ADMIN 페이지 접근을 위한 권한 기반 로직 구현 내역을 정리합니다.
+
+## 주요 변경점
+
+- **JWT 페이로드 확장** : 토큰 생성 시 사용자 `role` 값을 포함하도록 수정했습니다.
+- **타입 정의 업데이트** : `TokenData`와 `UserSession` 인터페이스에 `role` 필드가 추가되었습니다.
+- **API 응답 개선** : `/api/auth/sign_in`과 `/api/auth/refresh` 라우트가 로그인 및 토큰 갱신 시 역할 정보를 반환합니다.
+- **미들웨어 강화** : `middleware.ts`에서 갱신 API 응답을 확인하여 ADMIN 권한이 없는 경우 접근을 차단합니다.
+- **API 미들웨어 추가** : `requireRole` 함수를 도입하여 서버 라우트에서 손쉽게 역할 검사를 수행할 수 있습니다.
+
+## 사용 방법
+
+```ts
+import { requireRole } from '@/api/_libs';
+
+export async function GET(req: NextRequest) {
+  return requireRole(req, 'ADMIN', async () => {
+    // ADMIN 전용 로직
+    return NextResponse.json({ ok: true });
+  });
+}
+```
+
+ADMIN 전용 페이지는 기존과 동일하게 `/admin/*` 경로를 사용하며, 미들웨어에서 토큰을 갱신하고 역할을 검증합니다.

--- a/middleware.ts
+++ b/middleware.ts
@@ -50,7 +50,13 @@ export async function middleware(request: NextRequest) {
 
     // 4. API 응답 처리
     if (response.ok) {
-      // 4.1. 갱신 성공: 다음 요청으로 진행하되, API가 설정한 쿠키를 포함
+      // 4.1. 갱신 성공: 응답에서 사용자 역할 확인
+      const data = await response.json();
+      if (data.response.role !== 'ADMIN') {
+        console.log('ADMIN 권한이 없어 접근을 차단합니다.');
+        return NextResponse.redirect(new URL('/', request.url));
+      }
+
       console.log('관리자 토큰 갱신 성공, 관리자 페이지 접근 허용...');
       const nextResponse = NextResponse.next(); // 다음 미들웨어/페이지로 진행
 


### PR DESCRIPTION
## Summary
- include `role` in JWT payloads and session types
- add role check middleware helpers
- verify ADMIN role in middleware
- expose new API helpers
- document role-based auth usage

## Testing
- `pnpm lint` *(fails: 10094 errors, 21314 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684a6b3e9854832aa8170e3fce2364d2