### PR TITLE
Implement unified auth token check

### DIFF
--- a/app/api/_libs/authCheck.ts
+++ b/app/api/_libs/authCheck.ts
@@ -1,0 +1,45 @@
+import type { NextRequest } from 'next/server';
+
+import type { UserSession } from '@/_entities/users';
+import { DB } from './prisma';
+import { refresh } from './refresh';
+import { checkTokenValidity } from './tokenUtils';
+import { serverTools } from './tools';
+
+export interface AuthCheckResult {
+  error: boolean;
+  status: number;
+  message: string;
+  user?: UserSession;
+  accessToken?: string;
+}
+
+export async function authCheck(request: NextRequest): Promise<AuthCheckResult> {
+  const { accessToken, refreshToken, accessValid, refreshValid } = await checkTokenValidity();
+
+  if (!accessValid && !refreshValid) {
+    return { error: true, status: 401, message: '로그인이 필요합니다.' };
+  }
+
+  let validAccessToken = accessToken?.token;
+
+  if (!accessValid && refreshValid) {
+    const refreshResult = await refresh();
+
+    if (refreshResult.status !== 200) {
+      return { error: true, status: 401, message: '토큰 갱신 실패' };
+    }
+
+    validAccessToken = refreshResult.data.accessToken;
+  }
+
+  const tokenInfo = await serverTools.jwt.tokenInfo('accessToken', validAccessToken);
+  const user = await DB.user().findUnique({ where: { id: tokenInfo.id } });
+
+  if (!user) {
+    return { error: true, status: 404, message: '사용자 정보를 찾을 수 없습니다.' };
+  }
+
+  return { error: false, status: 200, message: 'OK', user, accessToken: validAccessToken };
+}
+

--- a/app/api/_libs/index.ts
+++ b/app/api/_libs/index.ts
@@ -4,3 +4,4 @@ export { createResponse } from './createResponse';
 export { checkTokenValidity } from './tokenUtils';
 export { refresh } from './refresh';
 export { refreshCheck } from './refreshCheck';
+export { authCheck } from './authCheck';

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,21 +1,23 @@
 import { NextRequest } from 'next/server';
 
 import { createResponse } from '@/api/_libs';
-import { getValidSession } from '@/api/_libs/session';
+import { authCheck } from '@/api/_libs/authCheck';
 
 export async function GET(request: NextRequest) {
   try {
-    const result = await getValidSession(request);
+    const result = await authCheck(request);
+
     if (result.error) {
       return createResponse<null>({
         message: result.message,
         status: result.status,
       });
     }
+
     return createResponse({
       message: '성공',
       status: 200,
-      data: result.session,
+      data: result.user,
     });
   } catch (error) {
     return createResponse<null>({


### PR DESCRIPTION
## Summary
- add `authCheck` in API libs to combine token validation and refresh logic
- export `authCheck` from API libs index
- use `authCheck` in auth/session API route

## Testing
- `pnpm lint` *(fails: 31704 problems)*

------
https://chatgpt.com/codex/tasks/task_e_684dc0f28030832ab6074a9a16119490