### PR TITLE
Add missing auth and user messages

### DIFF
--- a/app/(auth)/auth/signin/_components/SignInForm.tsx
+++ b/app/(auth)/auth/signin/_components/SignInForm.tsx
@@ -4,6 +4,8 @@ import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import { useState } from 'react';
 
+import { messageData } from '@/_data';
+
 import { Button } from '@/(common)/_components/ui/button';
 
 export function SignInForm() {
@@ -26,13 +28,13 @@ export function SignInForm() {
       });
 
       if (result?.error) {
-        setError('이메일 또는 비밀번호가 올바르지 않습니다.');
+        setError(messageData.auth.invalidCredentials);
       } else {
         router.push('/admin');
         router.refresh();
       }
     } catch (error) {
-      setError('로그인 중 오류가 발생했습니다.');
+      setError(messageData.auth.signInError);
     } finally {
       setIsLoading(false);
     }

--- a/app/(auth)/auth/signup/_components/SignUpForm.tsx
+++ b/app/(auth)/auth/signup/_components/SignUpForm.tsx
@@ -4,6 +4,8 @@ import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import { useState } from 'react';
 
+import { messageData } from '@/_data';
+
 import { Button } from '@/(common)/_components/ui/button';
 
 export function SignUpForm() {
@@ -44,7 +46,7 @@ export function SignUpForm() {
       const data = await response.json();
 
       if (!response.ok) {
-        setError(data.message || '회원가입 중 오류가 발생했습니다.');
+        setError(data.message || messageData.auth.signUpError);
         return;
       }
 
@@ -57,14 +59,14 @@ export function SignUpForm() {
 
       if (signInResult?.error) {
         // 회원가입은 성공했지만 로그인 실패 시 로그인 페이지로 이동
-        router.push('/auth/signin?message=회원가입이 완료되었습니다. 로그인해주세요.');
+        router.push('/auth/signin?message=' + messageData.auth.signUpSuccess);
       } else {
         // 로그인 성공 시 관리자 페이지로 이동
         router.push('/admin');
         router.refresh();
       }
     } catch (error) {
-      setError('회원가입 중 오류가 발생했습니다.');
+      setError(messageData.auth.signUpError);
     } finally {
       setIsLoading(false);
     }

--- a/app/_data/message.data.ts
+++ b/app/_data/message.data.ts
@@ -12,6 +12,10 @@ export const messageData = {
 
   auth: {
     signUpSuccess: '관리자 계정이 성공적으로 생성되었습니다.',
+    signUpError: '회원가입 중 오류가 발생했습니다.',
+    signInSuccess: '성공적으로 로그인되었습니다.',
+    signInError: '로그인 중 오류가 발생했습니다.',
+    signOutSuccess: '성공적으로 로그아웃되었습니다.',
     emailInUse: '이미 등록된 이메일입니다.',
     invalidCredentials: '이메일 또는 비밀번호가 올바르지 않습니다.',
     sessionExpired: '세션이 만료되었습니다. 다시 로그인해주세요.',
@@ -22,6 +26,10 @@ export const messageData = {
     updateSuccess: '관리자 정보가 수정되었습니다.',
     passwordChangeSuccess: '비밀번호가 변경되었습니다.',
     imageChangeSuccess: '프로필 이미지가 변경되었습니다.',
+    listSuccess: '관리자 목록 조회가 완료되었습니다.',
+    listError: '관리자 목록 조회를 실패했습니다.',
+    fetchSuccess: '관리자 상세 정보 조회가 완료되었습니다.',
+    fetchError: '관리자 상세 정보 조회를 실패했습니다.',
     emailExists: '해당 이메일은 이미 사용 중입니다.',
     nameExists: '해당 이름은 이미 존재합니다.',
     deleteSuccess: '관리자가 삭제되었습니다.',

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -4,6 +4,7 @@ import type { CreateUser } from '@/_entities/users';
 import { DB } from '@/api/_libs';
 import { serverTools } from '@/api/_libs';
 import { createResponse } from '@/api/_libs';
+import { messageData } from '@/_data';
 
 export async function POST(request: NextRequest) {
   try {
@@ -26,7 +27,7 @@ export async function POST(request: NextRequest) {
     if (findUser) {
       return createResponse({
         status: 409,
-        message: '이미 존재하는 이메일입니다.',
+        message: messageData.auth.emailInUse,
       });
     }
 
@@ -52,7 +53,7 @@ export async function POST(request: NextRequest) {
 
     return createResponse({
       status: 201,
-      message: '회원가입이 완료되었습니다.',
+      message: messageData.auth.signUpSuccess,
       data: newUser,
     });
 
@@ -61,7 +62,7 @@ export async function POST(request: NextRequest) {
 
     return createResponse({
       status: 500,
-      message: '회원가입 중 오류가 발생했습니다.',
+      message: messageData.auth.signUpError,
     });
   }
 }

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -26,14 +26,15 @@ export async function GET(request: NextRequest, { params, }: Params) {
     }
 
     return createResponse<User>({
-      message: '사용자 상세 정보 조회가 완료되었습니다.',
+      message: messageData.user.fetchSuccess,
       status: 200,
+      data: user,
     });
   } catch (error) {
     console.error(error, '사용자 상세 정보 조회 실패');
 
     return createResponse<null>({
-      message: '사용자 상세 정보 조회를 실패했습니다.',
+      message: messageData.user.fetchError,
       status: 500,
     });
   }


### PR DESCRIPTION
## Summary
- add additional success/failure texts for auth and user features
- reuse message constants in signup API and auth forms
- update user detail API to use new messages

## Testing
- `npm run lint` *(fails: Too many eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f7986f4c0832aab07c00d2c17d008